### PR TITLE
fix(build): Include optional platform headers

### DIFF
--- a/source/allocator_cfx.cpp
+++ b/source/allocator_cfx.cpp
@@ -7,6 +7,9 @@
 
 #include <EASTL/allocator.h>
 #include <EASTL/internal/config.h>
+#if __has_include(<malloc.h>)
+	#include <malloc.h>
+#endif
 
 #include <new>
 


### PR DESCRIPTION
Some systems like Ubuntu declare "memalign" in <malloc.h> instead of <stdlib.h> which makes building fail on those systems (Main repo Github runners for example).

Portability could still be improved with including other possible headers, but for the usage of this fork this should work just fine.

Tagging for visibility as this is a "cold" repo:
@prikolium-cfx @FabianTerhorst 